### PR TITLE
docs: add additional test instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,11 @@ Unit tests are under development using the pytest framework. Contributions are w
 
 Test are run on a fork of the main net using ganache-cli. You need to install it with `npm install -g ganache-cli` before running tests.
 
-To run the full test suite, in the project directory set the `MAINNET_PROVIDER` and `PROVIDER` env variables and run:
+To run the full test suite, in the project directory set the `PROVIDER` env variable to a mainnet provider, and run:
 
 ```
 poetry install
-export MAINNET_PROVIDER= # URL of provider, e.g. https://mainnet.infura.io/v3/...
-export PROVIDER=$MAINNET_PROVIDER
+export PROVIDER= # URL of provider, e.g. https://mainnet.infura.io/v3/...
 make test
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,9 +41,12 @@ Unit tests are under development using the pytest framework. Contributions are w
 
 Test are run on a fork of the main net using ganache-cli. You need to install it with `npm install -g ganache-cli` before running tests.
 
-To run the full test suite, in the project directory run:
+To run the full test suite, in the project directory set the `MAINNET_PROVIDER` and `PROVIDER` env variables and run:
 
 ```
+poetry install
+export MAINNET_PROVIDER= # URL of provider, e.g. https://mainnet.infura.io/v3/...
+export PROVIDER=$MAINNET_PROVIDER
 make test
 ```
 


### PR DESCRIPTION
I'm new to poetry workflows, and noticed that the test suite assumes two environment variables are set. 

By the way, is there any particular reason why MAINNET_PROVIDER and PROVIDER can't be consolidated into a single variable?