### PR TITLE
docs: update quoter description

### DIFF
--- a/uniswap/uniswap.py
+++ b/uniswap/uniswap.py
@@ -162,7 +162,7 @@ class Uniswap:
         fee: int = None,
         route: Optional[List[AddressLike]] = None,
     ) -> int:
-        """Returns the amount of the input token you get for `qty` of the output token"""
+        """Given `qty` amount of `token0`, returns the maximum output amount of `token1`."""
         if fee is None:
             fee = 3000
             if self.version == 3:
@@ -183,7 +183,7 @@ class Uniswap:
         fee: int = None,
         route: Optional[List[AddressLike]] = None,
     ) -> int:
-        """Returns the amount of input token you need to get `qty` of the output token"""
+        """Returns the minimum amount of `token0` required to buy `qty` amount of `token1`."""
         if fee is None:
             fee = 3000
             if self.version == 3:


### PR DESCRIPTION
Hi, thanks for this library to interact with Uniswap V3 protocol. I found it very helpful as an example.

I noticed that some of the documentation for the `get_price_input` and `get_price_output` functions was a little bit unclear, causing some confusion about which of `token0` or `token1` was the input or output token.

We stubbed our toe on this, especially the phrasing "the amount of the input token you get for `qty` of the output token" - which is using the words "input" and "output" opposite from how they are typically used.

This PR clarifies the documentation of those methods.