### PR TITLE
fix: added kovan to _netid_to_name

### DIFF
--- a/uniswap/constants.py
+++ b/uniswap/constants.py
@@ -6,6 +6,7 @@ _netid_to_name = {
     1: "mainnet",
     3: "ropsten",
     4: "rinkeby",
+    42: "kovan",
     56: "binance",
     97: "binance_testnet",
     137: "polygon",


### PR DESCRIPTION
Kovan was missing from the _netid_to_name causing an error. API can now connect to Kovan.