### PR TITLE
feat: add support for Harmony One (SushiSwap V2)

### DIFF
--- a/uniswap/constants.py
+++ b/uniswap/constants.py
@@ -15,6 +15,8 @@ _netid_to_name = {
     250: "fantom",
     42161: "arbitrum",
     421611: "arbitrum_testnet",
+    1666600000: "harmony_mainnet",
+    1666700000: "harmony_testnet",
 }
 
 _factory_contract_addresses_v1 = {
@@ -36,6 +38,9 @@ _factory_contract_addresses_v2 = {
     "xdai": "0xA818b4F111Ccac7AA31D0BCc0806d64F2E0737D7",
     "binance": "0xcA143Ce32Fe78f1f7019d7d551a6402fC5350c73",
     "binance_testnet": "0x6725F303b657a9451d8BA641348b6761A6CC7a17",
+    # SushiSwap on Harmony
+    "harmony_mainnet": "0xc35DADB65012eC5796536bD9864eD8773aBc74C4",
+    "harmony_testnet": "0xc35DADB65012eC5796536bD9864eD8773aBc74C4",
 }
 
 _router_contract_addresses_v2 = {
@@ -46,4 +51,7 @@ _router_contract_addresses_v2 = {
     "xdai": "0x1C232F01118CB8B424793ae03F870aa7D0ac7f77",
     "binance": "0x10ED43C718714eb63d5aA57B78B54704E256024E",
     "binance_testnet": "0xD99D1c33F9fC3444f8101754aBC46c52416550D1",
+    # SushiSwap on Harmony
+    "harmony_mainnet": "0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506",
+    "harmony_testnet": "0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506",
 }


### PR DESCRIPTION
both mainnet and testnet
using SushiSwap's V2 factory/router contract