### PR TITLE
test: add test for ValueError in make_trade_output

### DIFF
--- a/tests/test_uniswap.py
+++ b/tests/test_uniswap.py
@@ -472,6 +472,7 @@ class TestUniswap(object):
                 None,
                 lambda: pytest.raises(InsufficientBalance),
             ),
+            ("DAI", "DAI", ONE_USDC, None, lambda: pytest.raises(ValueError)),
         ],
     )
     def test_make_trade_output(


### PR DESCRIPTION
I will like to work on issue #265

Tested locally and test runs well. I also pushed a PR on my own fork to test. 
In this PR I added a simple test to slightly improve code coverage and also to test the workflow