### PR TITLE
Lowered approval check

### DIFF
--- a/uniswap/uniswap.py
+++ b/uniswap/uniswap.py
@@ -137,7 +137,7 @@ class Uniswap:
         # with each trade.
         max_approval_hex = f"0x{64 * 'f'}"
         self.max_approval_int = int(max_approval_hex, 16)
-        max_approval_check_hex = f"0x{15 * '0'}{49 * 'f'}"
+        max_approval_check_hex = f"0x{40 * '0'}{20 * 'f'}"
         self.max_approval_check_int = int(max_approval_check_hex, 16)
 
         if self.version == 1:


### PR DESCRIPTION
More of a workaround than a solution

Some tokens store the allowance as uint96, instead of uint256. So even if you approve the max, the allowance will return 79228162514264337593543950335 (the highest value for uint96) instead of 115792089237316195423570985008687907853269984665640564039457584007913129639935 (highest value for uint256)

This can be seen on some tokens, such as UNI on Goerli
https://goerli.etherscan.io/address/0x1f9840a85d5af5bf1d1762f925bdaddc4201f984#readContract

CVP on mainnet:
https://etherscan.io/address/0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1#readContract

INST on mainnet:
https://etherscan.io/token/0x6f40d4a6237c257fff2db00fa0510deeecd303eb#readProxyContract

Here's a table with the max value for each type
https://velvetshark.com/articles/max-int-values-in-solidity
