### PR TITLE
fix: `fee` argument not respected in `make_trade_output`

### DIFF
--- a/uniswap/uniswap.py
+++ b/uniswap/uniswap.py
@@ -507,7 +507,7 @@ class Uniswap:
 
         if input_token == ETH_ADDRESS:
             balance = self.get_eth_balance()
-            need = self._get_eth_token_output_price(output_token, qty)
+            need = self._get_eth_token_output_price(output_token, qty, fee)
             if balance < need:
                 raise InsufficientBalance(balance, need)
             return self._eth_to_token_swap_output(


### PR DESCRIPTION
Bug: The `make_trade_output` function accepts the `fee` parameter but doesn't pass it to the `self._get_eth_token_output_price` function.

This PR fixes this bug.