### PR TITLE
fix: update ganache version to fix arbitrum test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Install dependencies
       run: |
         poetry install
-        npm install -g ganache@7.3.2
+        npm install -g ganache@7.5.0
 
     - name: Test
       env:


### PR DESCRIPTION
Arbitrum tests have been failing due to a `Invalid transaction type: 106` error. More [info](https://github.com/trufflesuite/ganache/issues/3606).

This is fixed in the newer version of ganache.