### PR TITLE
fix: ContractFunction in web3.contract is deprecated

### DIFF
--- a/uniswap/uniswap.py
+++ b/uniswap/uniswap.py
@@ -8,7 +8,8 @@ from typing import List, Any, Optional, Sequence, Union, Tuple, Iterable, Dict
 from web3 import Web3
 from web3._utils.abi import map_abi_data
 from web3._utils.normalizers import BASE_RETURN_NORMALIZERS
-from web3.contract import Contract, ContractFunction
+from web3.contract import Contract
+from web3.contract.base_contract import BaseContractFunction as ContractFunction
 from web3.exceptions import BadFunctionCallOutput, ContractLogicError
 from web3.types import (
     TxParams,


### PR DESCRIPTION

In the latest version of web3 (6.0.0), the ContractFunction in web3.contract has been deprecated. It has been replaced by the BaseContractFunction. This change has been made to improve the functionality of the package and to provide developers with a more efficient way of working with smart contracts on the Ethereum blockchain. The BaseContractFunction offers a wider range of features that allow developers to interact with smart contracts in a more flexible and modular way. 