### PR TITLE
Update uniswap.py

### DIFF
--- a/uniswap/uniswap.py
+++ b/uniswap/uniswap.py
@@ -132,8 +132,13 @@ class Uniswap:
 
         if enable_caching:
             self.w3.middleware_onion.inject(_get_eth_simple_cache_middleware(), layer=0)
-
-        self.netid = int(self.w3.net.version)
+            
+        try:
+            self.netid = int(self.w3.net.version)
+        except ValueError:  
+            # Happens when w3.net.version returns a hex representation of an int
+            self.netid = int(self.w3.net.version, 16)
+        
         if self.netid in _netid_to_name:
             self.netname = _netid_to_name[self.netid]
         else:


### PR DESCRIPTION
This change fixes a ValueError exception caused by web3.py, when using `self.w3.net.version` it can return a hexadecimal number which needs to be handled differently than a regular integer.

Basically,
```py
self.netid = int(self.w3.net.version)
```
will throw a ValueError because the number of the version is returned in hexadecimal format 0x1, which needs to be translated from base-16 instead of base-10 which is now properly handled by a try and catch clause.

