### PR TITLE
Update uniswap.py - Resolve exception that is thrown when trying to trade two coins in the same wallet

### DIFF
--- a/uniswap/uniswap.py
+++ b/uniswap/uniswap.py
@@ -1456,7 +1456,7 @@ class Uniswap:
         # TODO: This needs to get more complicated if we want to support replacing a transaction
         # FIXME: This does not play nice if transactions are sent from other places using the same wallet.
         try:
-            return self.w3.eth.send_raw_transaction(signed_txn.rawTransaction)
+            return self.w3.eth.send_raw_transaction(signed_txn.raw_transaction)
         finally:
             logger.debug(f"nonce: {tx_params['nonce']}")
             self.last_nonce = Nonce(tx_params["nonce"] + 1)


### PR DESCRIPTION
Resolves the exception error when trying to trade eth to another coin on the same wallet. I can't remember the exact exception but this fixed it for me.