### PR TITLE
fix(ci): replace rate-limited Infura with public RPC

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   PROVIDER_MAINNET: ${{ secrets.MAINNET_PROVIDER || 'https://ethereum.publicnode.com' }}
-  PROVIDER_ARBITRUM: 'https://rpc.ankr.com/arbitrum'
+  PROVIDER_ARBITRUM: 'https://arb1.arbitrum.io/rpc'
   PROVIDER_XDAI: 'https://rpc.ankr.com/gnosis'
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,13 +2,12 @@ name: Test
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, dev/v4, dev/v4-fin ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, dev/v4, dev/v4-fin ]
 
 env:
-  # Public key for PRs, plz don't abuse
-  PROVIDER_MAINNET: ${{ secrets.MAINNET_PROVIDER || 'https://mainnet.infura.io/v3/42ffb4f2549c4a5fa3b5d6db70f6fad1' }}
+  PROVIDER_MAINNET: ${{ secrets.MAINNET_PROVIDER || 'https://ethereum.publicnode.com' }}
   PROVIDER_ARBITRUM: 'https://rpc.ankr.com/arbitrum'
   PROVIDER_XDAI: 'https://rpc.ankr.com/gnosis'
 

--- a/uniswap/uniswap4.py
+++ b/uniswap/uniswap4.py
@@ -1433,12 +1433,12 @@ class Uniswap4:
         try:
             name = _name.decode()
         except Exception:
-            name = _name
+            name = str(_name)
         try:
             symbol = _symbol.decode()
         except Exception as e:
             logger.warning(f"Error occurred while decoding symbol for {address}: {e}")
-            symbol = _symbol
+            symbol = str(_symbol)
         return ERC20Token(symbol, address, name, decimals)
 
     # Estimates slippage for the given amount of token0

--- a/uniswap/uniswap4.py
+++ b/uniswap/uniswap4.py
@@ -1437,7 +1437,11 @@ class Uniswap4:
         try:
             symbol = _symbol.decode()
         except Exception as e:
-            logger.warning(f"Error occurred while decoding symbol for {address}: {e}")
+            logger.warning(
+                "Error occurred while decoding symbol for %s: %s",
+                _addr_to_str(address),
+                e,
+            )
             symbol = str(_symbol)
         return ERC20Token(symbol, address, name, decimals)
 

--- a/uniswap/util.py
+++ b/uniswap/util.py
@@ -261,7 +261,7 @@ class V4pools:
                 #     "fromBlock": str(start_block),
                 #     "toBlock": str(end_block),
                 # }
-                logs = pool_manager_contract.events.Initialize().get_logs(
+                logs = pool_manager_contract.events.Initialize().get_logs(  # type: ignore[attr-defined]
                     fromBlock=start_block, toBlock=end_block
                 )
             except Exception as e:


### PR DESCRIPTION
## Summary

- Replace the rate-limited public Infura key with `ethereum.publicnode.com` as the default mainnet RPC provider
- Add `dev/v4` and `dev/v4-fin` branches to CI triggers so tests actually run on v4 work
- Fix two mypy type errors (`get_logs` attr on `BaseContractEvent`, bytes→str fallback in token decode)

## Context

CI was failing on every push to `dev/v4-fin` because:
1. **Tests**: Ganache couldn't fork mainnet — the public Infura key returns `429 Too Many Requests`
2. **Typecheck**: Two mypy errors in v4 code (bytes/str handling, missing web3 attribute)

Fixes #430.

## Test plan

- [ ] CI passes on this PR (tests + typecheck)
- [ ] Ganache successfully forks mainnet via publicnode.com