### PR TITLE
fix(ci): stop push runs from preferring stale mainnet secret

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,9 @@ on:
     branches: [ master, dev/v4, dev/v4-fin ]
 
 env:
-  PROVIDER_MAINNET: ${{ secrets.MAINNET_PROVIDER || 'https://ethereum.publicnode.com' }}
+  # The repo secret still points at a rate-limited Infura URL, so CI must use
+  # the public endpoint directly instead of preferring the secret on push runs.
+  PROVIDER_MAINNET: 'https://ethereum.publicnode.com'
   PROVIDER_ARBITRUM: 'https://arb1.arbitrum.io/rpc'
   PROVIDER_XDAI: 'https://rpc.ankr.com/gnosis'
 


### PR DESCRIPTION
## Summary
- stop the test workflow from preferring `secrets.MAINNET_PROVIDER`
- always use `https://ethereum.publicnode.com` for mainnet CI forks

## Why
PR #431 fixed the fallback URL, but the post-merge push run on `dev/v4-fin` still consumed the repo secret on push jobs. That secret is a stale Infura URL, so Ganache still failed with `Too Many Requests`.

Evidence:
- PR run for #431 used `PROVIDER_MAINNET: https://ethereum.publicnode.com` and passed the mainnet jobs
- post-merge push run for commit `b2eb3a0` showed `PROVIDER_MAINNET: ***` and failed with `Invalid response from fork provider: {"code":-32005,"message":"Too Many Requests"...see https://infura.io/dashboard}`

This makes push CI behave differently from the PR run, which is dumb. CI should use the known-good public endpoint directly until the secret is updated or removed.

## Notes
- This only fixes the mainnet regression from the stale secret.
- The remaining `test (v3, arbitrum)` failure is separate and was already present after #431.
