### PR TITLE
fix: avoid duplicate WETH in swap path when input/output is WETH (closes #363)

### DIFF
--- a/uniswap/uniswap.py
+++ b/uniswap/uniswap.py
@@ -1010,11 +1010,17 @@ class Uniswap:
                 input_token, output_token, qty, fee=fee
             )
             amount_in_max = int((1 + slippage) * cost)
+            weth = self.get_weth_address()
+            path = (
+                [input_token, output_token]
+                if input_token == weth or output_token == weth
+                else [input_token, weth, output_token]
+            )
             return self._build_and_send_tx(
                 self.router.functions.swapTokensForExactTokens(
                     qty,
                     amount_in_max,
-                    [input_token, self.get_weth_address(), output_token],
+                    path,
                     recipient,
                     self._deadline(),
                 ),

--- a/uniswap/uniswap.py
+++ b/uniswap/uniswap.py
@@ -1013,7 +1013,7 @@ class Uniswap:
             weth = self.get_weth_address()
             path = (
                 [input_token, output_token]
-                if input_token == weth or output_token == weth
+                if is_same_address(input_token, weth) or is_same_address(output_token, weth)
                 else [input_token, weth, output_token]
             )
             return self._build_and_send_tx(

--- a/uniswap/uniswap.py
+++ b/uniswap/uniswap.py
@@ -742,11 +742,17 @@ class Uniswap:
                 )
             else:
                 func = self.router.functions.swapExactTokensForTokens
+            weth_address = self.get_weth_address()
+            if is_same_address(input_token, weth_address) or is_same_address(output_token, weth_address):
+                path = [input_token, output_token]
+            else:
+                path = [input_token, weth_address, output_token]
+
             return self._build_and_send_tx(
                 func(
                     qty,
                     min_tokens_bought,
-                    [input_token, self.get_weth_address(), output_token],
+                    path,
                     recipient,
                     self._deadline(),
                 ),


### PR DESCRIPTION
## What
When swapping a token to WETH (or WETH to a token) using v2, the routing path was always constructed as `[input_token, weth_address, output_token]`. If either `input_token` or `output_token` is WETH, this results in a path like `[USDT, WETH, WETH]`, which causes the DEX router to revert with `IDENTICAL_ADDRESSES`.

## Fix
Before building the swap path, check whether the input or output token is already WETH. If so, use a direct path `[input_token, output_token]` instead of routing through WETH as an intermediate hop.

Closes #363