### PR TITLE
docs: disclose project funding history in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,13 @@ make test
 poetry run pytest --capture=no  # doesn't capture output (verbose)
 ```
 
-## Support our continued work!
+## Funding
 
-You can support us on [Gitcoin Grants](https://gitcoin.co/grants/2631/uniswap-python).
+Development of this library has been funded by:
+
+* The **[Uniswap Grants Program](https://www.uniswapfoundation.org/grants)**, which awarded a $15k grant (2021) that funded the development of Uniswap v3 support.
+* **Community donations** through [Gitcoin Grants](https://gitcoin.co/grants/2631/uniswap-python), which were used to compensate contributors (see [#181](https://github.com/uniswap-python/uniswap-python/discussions/181)).
+* **[Superuser Labs](https://superuserlabs.org/)**, Erik's company, which has sponsored continued development and maintenance, including funding [@liquid-8](https://github.com/liquid-8)'s work on Uniswap v4 support.
 
 ## Authors
 
@@ -76,8 +80,6 @@ You can support us on [Gitcoin Grants](https://gitcoin.co/grants/2631/uniswap-py
 * [Erik Bjäreholt](https://twitter.com/ErikBjare)
 * [@liquid-8](https://github.com/liquid-8)
 * ...and [others](https://github.com/uniswap-python/uniswap-python/graphs/contributors)
-
-*Want to help out with development? We have funding to those that do! See [#181](https://github.com/uniswap-python/uniswap-python/discussions/181)*
 
 Contributors also earn this beautiful [GitPOAP](https://gitpoap.notion.site/What-s-a-GitPOAP-5b085daac4b4429994b5231be028b3d9) for their contributions!
 


### PR DESCRIPTION
## Summary

Adds a **Funding** section to the README making the project's funding history explicit, ahead of the new Uniswap Foundation grant application:

- **Uniswap Grants Program** — $15k grant (2021) that funded Uniswap v3 support
- **Community donations** via Gitcoin Grants, used to compensate contributors (#181)
- **Superuser Labs** (Erik's company) — sponsored continued development and maintenance, including funding @liquid-8's work on Uniswap v4 support

It replaces the stale "Support our continued work!" section (the Gitcoin grant round is long over) and drops the 2021 "we have funding to those that do" note under Authors, which is now covered by the Funding section.

@liquid-8 this is the wording to mirror in the grant application — feel free to suggest edits.